### PR TITLE
Add an optional extra sleep before checking the child ssh tunnel process status 

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ No modules.
 | <a name="input_target_host"></a> [target\_host](#input\_target\_host) | The target host. Name will be resolved by gateway | `string` | n/a | yes |
 | <a name="input_target_port"></a> [target\_port](#input\_target\_port) | Target port number | `number` | n/a | yes |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Timeout value ensures tunnel cannot remain open forever | `string` | `"30m"` | no |
+| <a name="input_ssh_tunnel_check_sleep"></a> [ssh\_tunnel\_check\_sleep](#input\_ssh\_tunnel\_check\_sleep) | Extra wait time allows for accounting for slow ssh tunnel establish time | `string` | `"0s"` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ data external ssh_tunnel {
     target_port = var.target_port,
     gateway_host = local.gw,
     gateway_port = var.gateway_port,
-    shell_cmd = var.shell_cmd
+    shell_cmd = var.shell_cmd,
+    ssh_tunnel_check_sleep = var.ssh_tunnel_check_sleep
   }
 }

--- a/tunnel.sh
+++ b/tunnel.sh
@@ -24,6 +24,7 @@ if [ -z "$MPID" ] ; then
   export GATEWAY_HOST="`echo $query | sed -e 's/^.*\"gateway_host\": *\"//' -e 's/\".*$//g'`"
   export GATEWAY_PORT="`echo $query | sed -e 's/^.*\"gateway_port\": *\"//' -e 's/\".*$//g'`"
   export SHELL_CMD="`echo $query | sed -e 's/^.*\"shell_cmd\": *\"//' -e 's/\",.*$//g' -e 's/\\\"/\"/g'`"
+  export SSH_TUNNEL_CHECK_SLEEP="`echo $query | sed -e 's/^.*\"ssh_tunnel_check_sleep\": *\"//' -e 's/\",.*$//g' -e 's/\\\"/\"/g'`"
 
   echo "{ \"host\": \"$LOCAL_HOST\" }"
   p=`ps -p $PPID -o "ppid="`
@@ -50,6 +51,8 @@ else
 
   $SSH_CMD -N -L localhost:$LOCAL_PORT:$TARGET_HOST:$TARGET_PORT -p $GATEWAY_PORT $GATEWAY_HOST &
   CPID=$!
+  
+  sleep $SSH_TUNNEL_CHECK_SLEEP
 
   while true ; do
     if ! ps -p $CPID >/dev/null 2>&1 ; then

--- a/variables.tf
+++ b/variables.tf
@@ -62,3 +62,9 @@ variable "timeout" {
   description = "Timeout value ensures tunnel cannot remain open forever"
   default = "30m"
 }
+
+variable "ssh_tunnel_check_sleep" {
+  type = string
+  description = "extra time to wait for ssh tunnel to connect"
+  default = "0s"
+}


### PR DESCRIPTION
Certain ssh hosts may take longer to establish connection. In these cases the child process would immediately exit with a failure instead of giving enough time to setup the tunnel.

This adds an optional sleep before checking the child ssh tunnel process status