### PR TITLE
replace local.do_tunnel with var.create

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,8 @@
 
 locals {
-  do_tunnel = (var.create && var.gateway_host != null)
-  
   gw = (var.gateway_host == null) ? "" : (var.gateway_user == "" ? var.gateway_host : "${var.gateway_user}@${var.gateway_host}")
 }
-  
+
 
 data external free_port {
   program = [
@@ -15,7 +13,7 @@ data external free_port {
 }
 
 data external ssh_tunnel {
-  count = (local.do_tunnel ? 1 : 0)
+  count = var.create ? 1 : 0
   program = [
     var.shell_cmd,
     "${path.module}/tunnel.sh"

--- a/output.tf
+++ b/output.tf
@@ -1,11 +1,10 @@
 
 output "port" {
-  value = (local.do_tunnel ? data.external.free_port.result.port : var.target_port)
+  value = (var.create ? data.external.free_port.result.port : var.target_port)
   description = "Port number to connect to"
 }
 
 output "host" {
-  value = (local.do_tunnel ? data.external.ssh_tunnel[0].result.host : var.target_host)
+  value = (var.create ? data.external.ssh_tunnel[0].result.host : var.target_host)
   description = "Host to connect to"
 }
-


### PR DESCRIPTION
This MR replaces `local.do_tunnel` with `var.create`.

This fixes an issue that I came across when running terraform plan. I've attached a screenshot of the error I ran into.

I was using terraform v0.13.6.

![Screenshot from 2022-07-04 19-24-41](https://user-images.githubusercontent.com/3980722/177263864-ab1dbc69-9c0f-4b64-8015-676ffe2013be.png)
