### PR TITLE
Disable strict host key checking

### DIFF
--- a/tunnel.sh
+++ b/tunnel.sh
@@ -49,7 +49,7 @@ else
     env >&2
   fi
 
-  $SSH_CMD -N -L localhost:$LOCAL_PORT:$TARGET_HOST:$TARGET_PORT -p $GATEWAY_PORT $GATEWAY_HOST &
+  $SSH_CMD -o "StrictHostKeyChecking no" -N -L localhost:$LOCAL_PORT:$TARGET_HOST:$TARGET_PORT -p $GATEWAY_PORT $GATEWAY_HOST &
   CPID=$!
   
   sleep $SSH_TUNNEL_CHECK_SLEEP


### PR DESCRIPTION
Motivation:
If you try to tunnel through a host you haven't previously added to your `known_hosts` file before, the tunnel will fail with no meaningful input (I know this because I just spent 3 hours debugging it, and found the problem on a hunch).

Solution:
This basically disables host key validation altogether for all calls

Improvements:
The better solution would be some sort of var to control this behavior. However, I am not a sed user, and honestly I don't feel like learning that today - hopefully someone else can extend my solution with this improvement.