### PR TITLE
Add variable ssh_parent_wait_sleep for specifying extra wait time for child SSH process

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ No modules.
 | <a name="input_shell_cmd"></a> [shell\_cmd](#input\_shell\_cmd) | Command to run a shell | `string` | `"bash"` | no |
 | <a name="input_ssh_cmd"></a> [ssh\_cmd](#input\_ssh\_cmd) | Shell command to use to start ssh client | `string` | `"ssh -o StrictHostKeyChecking=no"` | no |
 | <a name="input_ssh_tunnel_check_sleep"></a> [ssh\_tunnel\_check\_sleep](#input\_ssh\_tunnel\_check\_sleep) | extra time to wait for ssh tunnel to connect | `string` | `"0s"` | no |
+| <a name="input_ssh_parent_wait_sleep"></a> [ssh\_parent\_wait\_sleep](#input\_ssh\_parent\_wait\_sleep) | extra time to wait in the parent process for the child ssh tunnel to open ports | `string` | `"3s"` | no |
 | <a name="input_target_host"></a> [target\_host](#input\_target\_host) | The target host. Name will be resolved by gateway | `string` | n/a | yes |
 | <a name="input_target_port"></a> [target\_port](#input\_target\_port) | Target port number | `number` | n/a | yes |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Timeout value ensures tunnel won't remain open forever | `string` | `"30m"` | no |

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ data external ssh_tunnel {
     gateway_user = var.gateway_user,
     shell_cmd = var.shell_cmd,
     ssh_tunnel_check_sleep = var.ssh_tunnel_check_sleep
+    ssh_parent_wait_sleep = var.ssh_parent_wait_sleep
     create = ((var.create && var.putin_khuylo) ? "y" : "")
   }
 }

--- a/tunnel.sh
+++ b/tunnel.sh
@@ -27,6 +27,7 @@ if [ -z "$MPID" ] ; then
   export GATEWAY_USER="`echo $query | sed -e 's/^.*\"gateway_user\": *\"//' -e 's/\".*$//g'`"
   export SHELL_CMD="`echo $query | sed -e 's/^.*\"shell_cmd\": *\"//' -e 's/\",.*$//g' -e 's/\\\"/\"/g'`"
   export SSH_TUNNEL_CHECK_SLEEP="`echo $query | sed -e 's/^.*\"ssh_tunnel_check_sleep\": *\"//' -e 's/\",.*$//g' -e 's/\\\"/\"/g'`"
+  export SSH_PARENT_WAIT_SLEEP="`echo $query | sed -e 's/^.*\"ssh_parent_wait_sleep\": *\"//' -e 's/\",.*$//g' -e 's/\\\"/\"/g'`"
   export CREATE="`echo $query | sed -e 's/^.*\"create\": *\"//' -e 's/\",.*$//g' -e 's/\\\"/\"/g'`"
 
   if [ "X$CREATE" = X -o "X$GATEWAY_HOST" = X ] ; then
@@ -48,7 +49,7 @@ if [ -z "$MPID" ] ; then
     nohup timeout $TIMEOUT $SHELL_CMD "$ABSPATH/tunnel.sh" $p <&- >&- 2>$clog &
     CPID=$!
     # A little time for the SSH tunnel process to start or fail
-    sleep 3
+    sleep $SSH_PARENT_WAIT_SLEEP
     # If the child process does not exist anymore after this delay, report failure
     if ! ps -p $CPID >/dev/null 2>&1 ; then
       echo "Child process ($CPID) failure - Aborting" >&2

--- a/variables.tf
+++ b/variables.tf
@@ -69,6 +69,12 @@ variable "ssh_tunnel_check_sleep" {
   default = "0s"
 }
 
+variable "ssh_parent_wait_sleep" {
+  type = string
+  description = "extra time to wait in the tunnel parent process for the child ssh tunnel startup"
+  default = "3s"
+}
+
 variable "putin_khuylo" {
   description = "Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo!"
   type        = bool


### PR DESCRIPTION
This is necessary in the case where the child SSH process takes longer than 3 seconds to open a local port for forwarding.

I notice this when I try to use terraform-ssh-tunnel with a host that is on the other side of the world from me.  It takes longer than 3 seconds for the child SSH process to actually open the local port that is being forwarded.

Without a longer wait time, I was seeing errors in Terraform when trying to use the local port.
