### PR TITLE
Use strict POSIX-compatible format for sleep arguments

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -66,13 +66,13 @@ variable "timeout" {
 variable "ssh_tunnel_check_sleep" {
   type = string
   description = "extra time to wait for ssh tunnel to connect"
-  default = "0s"
+  default = "0"
 }
 
 variable "ssh_parent_wait_sleep" {
   type = string
   description = "extra time to wait in the tunnel parent process for the child ssh tunnel startup"
-  default = "3s"
+  default = "3"
 }
 
 variable "putin_khuylo" {


### PR DESCRIPTION
For (better) compatibility with macOS and other non-GNU systems.

Symptoms are:

- "Connection refused" errors from plan/apply operations which use the tunnel.
- With `TUNNEL_DEBUG` non-empty, the `/tmp/t1` log file will have lines saying `usage: sleep seconds`.

(https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sleep.html)