### PR TITLE
Make terraform-ssh-tunnel work on Terraform Cloud by removing python dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ No modules.
 | <a name="input_gateway_user"></a> [gateway\_user](#input\_gateway\_user) | User to use on SSH gateway (default = empty string = current username) | `any` | `""` | no |
 | <a name="input_local_host"></a> [local\_host](#input\_local\_host) | Local host name or IP. Set only if you cannot use the '127.0.0.1' default value | `string` | `"127.0.0.1"` | no |
 | <a name="input_putin_khuylo"></a> [putin\_khuylo](#input\_putin\_khuylo) | Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo! | `bool` | `true` | no |
-| <a name="input_python_cmd"></a> [python\_cmd](#input\_python\_cmd) | Command to run python | `string` | `"python"` | no |
 | <a name="input_shell_cmd"></a> [shell\_cmd](#input\_shell\_cmd) | Command to run a shell | `string` | `"bash"` | no |
 | <a name="input_ssh_cmd"></a> [ssh\_cmd](#input\_ssh\_cmd) | Shell command to use to start ssh client | `string` | `"ssh -o StrictHostKeyChecking=no"` | no |
 | <a name="input_ssh_tunnel_check_sleep"></a> [ssh\_tunnel\_check\_sleep](#input\_ssh\_tunnel\_check\_sleep) | extra time to wait for ssh tunnel to connect | `string` | `"0s"` | no |

--- a/get-open-port.sh
+++ b/get-open-port.sh
@@ -1,1 +1,2 @@
-comm -23 <(seq 1 65535 | sort) <(ss -Htan | awk '{print $4}' | cut -d':' -f2 | sort -u) | shuf | head -n 1
+port=$(comm -23 <(seq 1 65535 | sort) <(ss -Htan | awk '{print $4}' | cut -d':' -f2 | sort -u) | shuf | head -n 1)
+echo "{\"port\": \"$port\"}"

--- a/get-open-port.sh
+++ b/get-open-port.sh
@@ -1,0 +1,1 @@
+comm -23 <(seq 1 65535 | sort) <(ss -Htan | awk '{print $4}' | cut -d':' -f2 | sort -u) | shuf | head -n 1

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,7 @@
-
 data external free_port {
   program = [
-    var.python_cmd,
-    "-c",
-    "import socket; s=socket.socket(); s.bind((\"\", 0)); print(\"{ \\\"port\\\": \\\"\" + str(s.getsockname()[1]) + \"\\\" }\"); s.close()"
+    var.shell_cmd,
+    "${path.module}/get-open-port.sh"
   ]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -5,12 +5,6 @@ variable "create" {
   default = true
 }
 
-variable "python_cmd" {
-  type = string
-  description = "Command to run python"
-  default = "python"
-}
-
 variable "shell_cmd" {
   type = string
   description = "Command to run a shell"


### PR DESCRIPTION
I don't have access to MacOS X and I'm not sure therefore that it will work on Mac, but this works on terraform cloud.

I'm leaving this here in case anyone else needs it.

Fixes #21