### PR TITLE
Correct var.env usage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ data "external" "ssh_tunnel" {
   query = {
     aws_profile        = var.aws_profile
     create             = ((var.create && var.putin_khuylo) ? "y" : "")
-    env                = join("\n", [for n, v in var.env : "export ${n}=\"${replace("\"", "\\\"", v)}\""])
+    env                = join("\n", [for n, v in var.env : "export ${n}=\"${replace(v, "\"", "\\\"")}\""])
     external_script    = var.external_script
     gateway_host       = var.gateway_host
     gateway_port       = var.gateway_port

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ data "external" "ssh_tunnel" {
   query = {
     aws_profile        = var.aws_profile
     create             = ((var.create && var.putin_khuylo) ? "y" : "")
-    env                = join("\n", [for n, v in var.env : "export ${n}=\"${replace(v, "\"", "\\\"")}\""])
+    env                = join(" ", [for n, v in var.env : "export ${n}=\"${replace(v, "\"", "\\\"")}\""])
     external_script    = var.external_script
     gateway_host       = var.gateway_host
     gateway_port       = var.gateway_port


### PR DESCRIPTION
Currently you can't use `var.env` to populate ENV variables in an external script.

This fixes these by doing the following:
1. Correcting the use of `replace(string, this, that)`
2. Using `space` to join the `export N="V"` since without that the `\n` is swallowed at some level with escapes.  Space is good enough as our values are surrounded by `"` 

That's enough to get my script operational.

I suspect there may be other issues with dangerous we might want to escape with `'` to protect against that, but I didn't have time to test.