### PR TITLE
remove spaces in ps output

### DIFF
--- a/tunnel.sh
+++ b/tunnel.sh
@@ -109,7 +109,7 @@ if [ -z "$TUNNEL_TF_PID" ] ; then
     if ps_is_busybox ; then
         p=$PPID
     else
-        p=$(ps p $PPID -o "ppid=")
+        p=$(ps p $PPID -o "ppid=" | sed 's/ //g')
     fi
     clog=$(mktemp)
     nohup timeout "$TUNNEL_TIMEOUT" "$TUNNEL_SHELL_CMD" "$TUNNEL_ABSPATH/tunnel.sh" "$p" <&- >&- 2>"$clog" &


### PR DESCRIPTION
I have found the following issue with a colleague of mine.

If we tried to use it on our Linux machines, we found the issue in the debugging that simply `ps p $PPID -o "ppid="` removes the header line but contains padding spaces in front. Which will be literal transferred to the underlying child script with “$p” and cause issues with the running detection because something like `p="  2134"` gives no valid return on later ps calls.