### PR TITLE
feat: add aws assume role support for ssm

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,36 +38,36 @@ You can also provide your own shell script if your gateway is not supported yet.
 
 ---
 <!--ts-->
-   * [Supported gateways](#supported-gateways)
-      * [SSH](#ssh)
-         * [Using multiple SSH gateways (ProxyJump)](#using-multiple-ssh-gateways-proxyjump)
-         * [Target host name resolution](#target-host-name-resolution)
-      * [AWS SSM](#aws-ssm)
-      * [Goggle IAP](#goggle-iap)
-      * [Kubernetes port forwarding](#kubernetes-port-forwarding)
-      * [External](#external)
-   * [Module output](#module-output)
-   * [Tunnel conditional creation](#tunnel-conditional-creation)
-   * [Environment](#environment)
-   * [Requirements](#requirements)
-      * [Posix shell](#posix-shell)
-      * ['timeout' utility](#timeout-utility)
-      * ['nohup' utility](#nohup-utility)
-      * [SSH client](#ssh-client)
-      * [AWS CLI](#aws-cli)
-      * [Kubectl](#kubectl)
-      * [gcloud CLI](#gcloud-cli)
-   * [Limitations](#limitations)
-      * [Running terraform apply from plan out](#running-terraform-apply-from-plan-out)
-   * [Examples](#examples)
-   * [To do](#to-do)
-      * [Add support for Azure bastion host tunnels](#add-support-for-azure-bastion-host-tunnels)
-   * [Requirements](#requirements-1)
-   * [Providers](#providers)
-   * [Modules](#modules)
-   * [Resources](#resources)
-   * [Inputs](#inputs)
-   * [Outputs](#outputs)
+- [Supported gateways](#supported-gateways)
+  - [SSH](#ssh)
+    - [Using multiple SSH gateways (ProxyJump)](#using-multiple-ssh-gateways-proxyjump)
+    - [Target host name resolution](#target-host-name-resolution)
+  - [AWS SSM](#aws-ssm)
+  - [Google IAP](#google-iap)
+  - [Kubernetes port forwarding](#kubernetes-port-forwarding)
+  - [External](#external)
+- [Module output](#module-output)
+- [Tunnel conditional creation](#tunnel-conditional-creation)
+- [Environment](#environment)
+- [Requirements](#requirements)
+  - [Posix shell](#posix-shell)
+  - ['timeout' utility](#timeout-utility)
+  - ['nohup' utility](#nohup-utility)
+  - [SSH client](#ssh-client)
+  - [AWS CLI](#aws-cli)
+  - [Kubectl](#kubectl)
+  - [gcloud CLI](#gcloud-cli)
+- [Limitations](#limitations)
+  - [Running terraform apply from plan out](#running-terraform-apply-from-plan-out)
+- [Examples](#examples)
+- [To do](#to-do)
+  - [Add support for Azure bastion host tunnels](#add-support-for-azure-bastion-host-tunnels)
+- [Requirements](#requirements-1)
+- [Providers](#providers)
+- [Modules](#modules)
+- [Resources](#resources)
+- [Inputs](#inputs)
+- [Outputs](#outputs)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
 <!-- Added by: flaupretre, at: Sat Aug 19 14:30:13 UTC 2023 -->
@@ -137,10 +137,10 @@ How to activate the SSM variant :
 - set 'gateway_host' to the instance ID of the EC2 gateway
 - set 'gateway_user' to the appropriate name (see documentation), generally
   'ec2-user' ('ubuntu' when using Ubuntu-based AMIs).
-- As an option, add environment variables, like 'AWS_PROFILE', into
-  the 'env' input array.
+- Optional: set `aws_assume_role` to assume a role before opening the SSM session (e.g. into a different AWS account)
+- As an option, add environment variables, like 'AWS_PROFILE', into the 'env' input array.
 
-### Goggle IAP
+### Google IAP
 
 This feature is EXPERIMENTAL and was never tested. You use it under your total responsibility.
 Among others, no assumption should be made on the security level it provides.

--- a/gateways/ssm.sh
+++ b/gateways/ssm.sh
@@ -8,6 +8,14 @@
 gw="$TUNNEL_GATEWAY_HOST"
 [ "X$TUNNEL_GATEWAY_USER" = X ] || gw="$TUNNEL_GATEWAY_USER@$TUNNEL_GATEWAY_HOST"
 
+
+# If AWS_ASSUME_ROLE is not empty, execute the assume-role command and
+# set the environment variables
+if [ -n "$AWS_ASSUME_ROLE" ] ; then
+  eval "$(aws sts assume-role --role-arn "$AWS_ASSUME_ROLE" --role-session-name="terraform-ssh-tunnel" --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text | awk '{ print "export AWS_ACCESS_KEY_ID=" $1 "\nexport AWS_SECRET_ACCESS_KEY=" $2 "\nexport AWS_SESSION_TOKEN=" $3 }')"
+fi
+
+
 $TUNNEL_SSH_CMD \
   -o ProxyCommand="aws ssm start-session $TUNNEL_SSM_OPTIONS --target %h --document-name $TUNNEL_SSM_DOCUMENT_NAME --parameters 'portNumber=%p'" \
   -N \

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ data "external" "ssh_tunnel" {
   ]
   query = {
     aws_profile        = var.aws_profile
+    aws_assume_role    = var.aws_assume_role
     create             = ((var.create && var.putin_khuylo) ? "y" : "")
     env                = join(" ", [for n, v in var.env : "export ${n}=\"${replace(v, "\"", "\\\"")}\""])
     external_script    = var.external_script

--- a/tunnel.sh
+++ b/tunnel.sh
@@ -84,11 +84,18 @@ if [ -z "$TUNNEL_TF_PID" ] ; then
   TUNNEL_TYPE="$(echo "$query" | sed -e 's/^.*\"type\": *\"//' -e 's/\".*$//g')"
   export TUNNEL_TYPE
 
+
   # Set AWS_PROFILE only if var is not empty
   profile="$(echo "$query" | sed -e 's/^.*\"aws_profile\": *\"//' -e 's/\",.*$//g' -e 's/\\\"/\"/g')"
   if [ -n "$profile" ] ; then
     AWS_PROFILE="$profile"
     export AWS_PROFILE
+  fi
+
+  role="$(echo "$query" | sed -e 's/^.*\"aws_assume_role\": *\"//' -e 's/\",.*$//g' -e 's/\\\"/\"/g')"
+  if [ -n "$role" ] ; then
+    AWS_ASSUME_ROLE="$role"
+    export AWS_ASSUME_ROLE
   fi
 
   if [ "X$TUNNEL_CREATE" = X -o "X$TUNNEL_GATEWAY_HOST" = X ] ; then

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,12 @@ variable "aws_profile" {
   default     = ""
 }
 
+variable "aws_assume_role" {
+  type        = string
+  description = "AWS SSM only - Role to assume before starting the session"
+  default     = ""
+}
+
 variable "create" {
   type        = bool
   description = "If false, do nothing and return target host"
@@ -134,4 +140,3 @@ variable "type" {
   description = "Gateway type"
   default     = "ssh"
 }
-


### PR DESCRIPTION
This adds an _optional_ `aws_assume_role` input which is used in the SSM tunnel. 
It will assume a given role _before_ starting the tunnel.

In our use-case we run Terraform in a separate account, which needs to assume a role into the target account before it can do any actions. 
For normal Terraform this is handled using the `assume_role`  functionality of the `aws` provider, but in this particular case we need to explicitly assume the role ourselves.

With these changes we were able to use the module without getting a "Permission Denied" error.