### PR TITLE
Fixup #44: Fixup bug when defining `ABSPATH` variable

### DIFF
--- a/tunnel.sh
+++ b/tunnel.sh
@@ -35,7 +35,7 @@ if [ -z "$TUNNEL_TF_PID" ] ; then
     env >&2
   fi
 
-  TUNNEL_ABSPATH=$(cd "$(dirname "$0")"; pwd -P)
+  TUNNEL_ABSPATH=$(cd "$(dirname "$0")" >/dev/null; pwd -P)
   export TUNNEL_ABSPATH
 
   query="$(dd 2>/dev/null)"


### PR DESCRIPTION
Using `cd` might cause shell to echo back new working directory (cf. issue https://github.com/flaupretre/terraform-ssh-tunnel/issues/44)

Proposed solution is to redirect `cd` output to `/dev/null`