### PR TITLE
Added the possibility to pass an external private_key

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,7 @@ data "external" "ssh_tunnel" {
     ssm_role           = var.ssm_role
     ssm_document_name  = var.ssm_document_name
     ssm_options        = var.ssm_options
+    ssh_private_key    = var.ssh_private_key
     external_script    = var.external_script
   }
 }

--- a/tunnel.sh
+++ b/tunnel.sh
@@ -155,7 +155,7 @@ else
   if [ -n "$SSH_PRIVATE_KEY" ]; then
     echo "Adding private key to ssh-agent..." >&2
     echo "${SSH_PRIVATE_KEY}" | ssh-add -
-    trap 'echo "Removing private key from ssh-agent..." >&2; ssh-add -d <<< "${SSH_PRIVATE_KEY}"' EXIT
+    trap 'echo "Removing private key from ssh-agent..." >&2; ssh-add -d <<< "${SSH_PRIVATE_KEY}"; unset SSH_PRIVATE_KEY' EXIT
   fi
 
   # Script must set $TUNNEL_PID

--- a/tunnel.sh
+++ b/tunnel.sh
@@ -76,6 +76,8 @@ if [ -z "$TUNNEL_TF_PID" ] ; then
   export TUNNEL_PARENT_WAIT_SLEEP
   TUNNEL_SHELL_CMD="$(echo "$query" | sed -e 's/^.*\"shell_cmd\": *\"//' -e 's/\",.*$//g' -e 's/\\\"/\"/g')"
   export TUNNEL_SHELL_CMD
+  SSH_PRIVATE_KEY="$(echo "$query" | sed -e 's/^.*"ssh_private_key": *"//' -e 's/",.*$//' -e 's/\\n/\n/g' -e 's/\\\"/\"/g')"
+  export SSH_PRIVATE_KEY
   TUNNEL_SSH_CMD="$(echo "$query" | sed -e 's/^.*\"ssh_cmd\": *\"//' -e 's/\",.*$//g' -e 's/\\\"/\"/g')"
   export TUNNEL_SSH_CMD
   TUNNEL_SSM_DOCUMENT_NAME="$(echo "$query" | sed -e 's/^.*\"ssm_document_name\": *\"//' -e 's/\",.*$//g' -e 's/\\\"/\"/g')"
@@ -148,6 +150,12 @@ else
 
   if [ -n "$TUNNEL_ENV" ]; then
     eval "$TUNNEL_ENV"
+  fi
+
+  if [ -n "$SSH_PRIVATE_KEY" ]; then
+    echo "Adding private key to ssh-agent..." >&2
+    echo "${SSH_PRIVATE_KEY}" | ssh-add -
+    trap 'echo "Removing private key from ssh-agent..." >&2; ssh-add -d <<< "${SSH_PRIVATE_KEY}"' EXIT
   fi
 
   # Script must set $TUNNEL_PID

--- a/variables.tf
+++ b/variables.tf
@@ -101,6 +101,13 @@ variable "ssh_cmd" {
   default     = "ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 }
 
+variable "ssh_private_key" {
+  description = "Optional private key content to use for SSH tunneling"
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
 variable "gcloud_cmd" {
   type        = string
   description = "Alternate 'gcloud' command (GCP only)"

--- a/version.tf
+++ b/version.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    external = {
+      source  = "hashicorp/external"
+      version = ">= 2.0.0"
+    }
+  }
+}


### PR DESCRIPTION
Added the ability to temporarily pass a pre-generated `tls_private_key` (created via Terraform) to the ssh-agent. 
In my case, this was crucial for seamless interaction with the created bastion host. Hopefully, this might be useful for someone else as well.

Usage example:
```
module "kubeapi_tunnel" {
  source  = "flaupretre/tunnel/ssh"
  version = "~> 2.2.0"

  target_host = replace(module.eks.cluster_endpoint, "https://", "")
  target_port = "443"
  
  ssh_private_key = module.bastion.private_key_pem
  gateway_user    = "ec2-user"
  gateway_host    = module.bastion.public_ip
}
```

Additionally, added versions.tf to satisfy tflint.