### PR TITLE
Use an empty string as the ssh_private_key default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -105,7 +105,7 @@ variable "ssh_private_key" {
   description = "Optional private key content to use for SSH tunneling"
   type        = string
   sensitive   = true
-  default     = null
+  default     = ""
 }
 
 variable "gcloud_cmd" {


### PR DESCRIPTION
With version 2.3.2 or later of hashicorp/external, null values in the `query` are removed: https://github.com/hashicorp/terraform-provider-external/issues/208

Which results in:

```
++ echo '{"create":"y","env":"","external_script":"undef","gateway_host":"bastion.staging.euw1.aws.hypervolt.co.uk","gateway_port":"22","gateway_user":"","gcloud_cmd":"gcloud","iap_project":"","iap_zone":"","kubectl_cmd":"kubectl","kubectl_context":"","kubectl_namespace":"","local_host":"127.0.0.1","local_port":"28584","parent_wait_sleep":"3","shell_cmd":"bash","ssh_cmd":"ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no","ssm_document_name":"AWS-StartSSHSession","ssm_options":"","ssm_profile":"","ssm_role":"","target_host":"pulsar.service.consul","target_port":"8081","timeout":"30m","tunnel_check_sleep":"0","type":"ssh"}'
++ sed -e 's/^.*"ssh_private_key": *"//' -e 's/",.*$//' -e 's/\\n/\n/g' -e 's/\\\"/\"/g'
+ SSH_PRIVATE_KEY='{"create":"y'
```

And even more weirdly, results in a key being removed from my ssh-agent:

Before:

```
$ ssh-add -l
256 SHA256:[redacted]  (ED25519)
256 SHA256:[redacted]  (ED25519)
3072 SHA256:[redacted] [redacted].local (RSA)
```

After:

```
$ ssh-add -l
256 SHA256:[redacted]  (ED25519)
256 SHA256:[redacted]  (ED25519)
```

Tested against:

```
Terraform v1.9.4
on darwin_arm64
+ provider registry.terraform.io/hashicorp/aws v5.100.0
+ provider registry.terraform.io/hashicorp/external v2.3.5
+ provider registry.terraform.io/streamnative/pulsar v0.5.1
```